### PR TITLE
Copier Template: Coverage: Declare equivalent paths for combining reports on GHA runners.

### DIFF
--- a/.github/workflows/xrepo--reporter.yaml
+++ b/.github/workflows/xrepo--reporter.yaml
@@ -29,10 +29,9 @@ jobs:
         run: |
           set -eu
           hatch --env develop run coverage combine
-          # Note: Ignore errors because of mismatched source paths in combined coverage.
-          hatch --env develop run coverage report --ignore-errors
-          hatch --env develop run coverage html --ignore-errors
-          hatch --env develop run coverage xml --ignore-errors
+          hatch --env develop run coverage report
+          hatch --env develop run coverage html
+          hatch --env develop run coverage xml
         shell: bash
 
       - name: Preserve Coverage Reports

--- a/.github/workflows/xrepo--tester.yaml
+++ b/.github/workflows/xrepo--tester.yaml
@@ -69,6 +69,7 @@ jobs:
         run: |
           set -eu
           v=${{ fromJSON(inputs.python-descriptors)[ matrix.python-version ].hatch }}
+          hatch --env "qa.${v}" run coverage --version
           hatch --env "qa.${v}" run coverage run
         shell: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,12 @@ emcdproj = 'emcdproj:main'
 year-of-origin = 2024
 
 # https://coverage.readthedocs.io/en/latest/config.html
+[tool.coverage.paths]
+gha-runners = [
+  '/home/runner/work/python-project-common/python-project-common/',
+  '/Users/runner/work/python-project-common/python-project-common/',
+  'D:\a\python-project-common\python-project-common\',
+]
 [tool.coverage.run]
 branch = true
 command_line = '-m pytest' # TODO? '--fail-under'

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -68,6 +68,12 @@ email = '{{ author_email }}'
 year-of-origin = {{ year_of_origin }}
 
 # https://coverage.readthedocs.io/en/latest/config.html
+[tool.coverage.paths]
+gha-runners = [
+  '/home/runner/work/{{ project_name }}/{{ project_name }}/',
+  '/Users/runner/work/{{ project_name }}/{{ project_name }}/',
+  'D:\a\{{ project_name }}\{{ project_name }}\',
+]
 [tool.coverage.run]
 branch = true
 command_line = '-m pytest' # TODO? '--fail-under'


### PR DESCRIPTION
Github Workflows: xrepo--reporter: Remove flag to ignore errors from incompatible paths.