### PR TITLE
Switch GitHub workflow templates to use floating version tags

### DIFF
--- a/template/.github/workflows/releaser.yaml.jinja
+++ b/template/.github/workflows/releaser.yaml.jinja
@@ -24,7 +24,7 @@ jobs:
 
   test:
     needs: [initialize]
-    uses: emcd/python-project-common/.github/workflows/xrepo--tester.yaml@{{ _commit }}
+    uses: emcd/python-project-common/.github/workflows/xrepo--tester.yaml@gha-1
     with:
       matrix-exclusions: {% raw %}'${{ needs.initialize.outputs.matrix-exclusions }}'{% endraw %}
       platforms: {% raw %}'${{ needs.initialize.outputs.platforms }}'{% endraw %}
@@ -36,7 +36,7 @@ jobs:
 
   report:
     needs: [initialize, test]
-    uses: emcd/python-project-common/.github/workflows/xrepo--reporter.yaml@{{ _commit }}
+    uses: emcd/python-project-common/.github/workflows/xrepo--reporter.yaml@gha-1
     with:
       python-version: {% raw %}'${{ fromJSON(needs.initialize.outputs.python-versions)[0] }}'{% endraw %}
 
@@ -46,14 +46,14 @@ jobs:
       contents: write
       id-token: write
       pages: write
-    uses: emcd/python-project-common/.github/workflows/xrepo--documenter.yaml@{{ _commit }}
+    uses: emcd/python-project-common/.github/workflows/xrepo--documenter.yaml@gha-1
     with:
       include-reports: true
       python-version: {% raw %}'${{ fromJSON(needs.initialize.outputs.python-versions)[0] }}'{% endraw %}
 
   package:
     needs: [initialize, docsgen]
-    uses: emcd/python-project-common/.github/workflows/xrepo--packager.yaml@{{ _commit }}
+    uses: emcd/python-project-common/.github/workflows/xrepo--packager.yaml@gha-1
     with:
       artifacts-path: '.auxiliary/artifacts/hatch-build' # TODO: Use environment.
       python-version: {% raw %}'${{ fromJSON(needs.initialize.outputs.python-versions)[0] }}'{% endraw %}
@@ -106,7 +106,7 @@ jobs:
         _PYI_EXECUTABLE_NAME: {{ distribution_name }}-{% raw %}${{ github.ref_name }}-${{ matrix.platform-name }}{% endraw %}
       steps:
         - name: Prepare Python
-          uses: emcd/python-project-common/.github/actions/python-hatch@{{ _commit }}
+          uses: emcd/python-project-common/.github/actions/python-hatch@gha-1
           with:
             python-version: {% raw %}${{ fromJSON(needs.initialize.outputs.python-versions)[0] }}{% endraw %}
 
@@ -163,7 +163,7 @@ jobs:
     steps:
 
       - name: Prepare Python
-        uses: emcd/python-project-common/.github/actions/python-hatch@{{ _commit }}
+        uses: emcd/python-project-common/.github/actions/python-hatch@gha-1
         with:
           python-version: {% raw %}${{ fromJSON(needs.initialize.outputs.python-versions)[0] }}{% endraw %}
 

--- a/template/.github/workflows/tester.yaml.jinja
+++ b/template/.github/workflows/tester.yaml.jinja
@@ -14,7 +14,7 @@ jobs:
 
   test:
     needs: [initialize]
-    uses: emcd/python-project-common/.github/workflows/xrepo--tester.yaml@{{ _commit }}
+    uses: emcd/python-project-common/.github/workflows/xrepo--tester.yaml@gha-1
     with:
       matrix-exclusions: {% raw %}'${{ needs.initialize.outputs.matrix-exclusions }}'{% endraw %}
       platforms: {% raw %}'${{ needs.initialize.outputs.platforms }}'{% endraw %}
@@ -26,6 +26,6 @@ jobs:
 
   report:
     needs: [initialize, test]
-    uses: emcd/python-project-common/.github/workflows/xrepo--reporter.yaml@{{ _commit }}
+    uses: emcd/python-project-common/.github/workflows/xrepo--reporter.yaml@gha-1
     with:
       python-version: {% raw %}'${{ fromJSON(needs.initialize.outputs.python-versions)[0] }}'{% endraw %}


### PR DESCRIPTION
Replace `{{ _commit }}` with `gha-1` floating tag in cross-repo workflow references.
This allows workflows to be updated independently of `copier update` runs.

The `gha-1` tag will point to the latest workflows release in the gha-1.x series.

Fixes #9

Generated with [Claude Code](https://claude.ai/code)